### PR TITLE
Don't Hard Code Text Color (and Minor Changes)

### DIFF
--- a/TadukooUtil/pom.xml
+++ b/TadukooUtil/pom.xml
@@ -25,6 +25,13 @@
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
+					<annotationProcessorPaths>
+						<annotationProcessorPath>
+							<groupId>${project.groupId}</groupId>
+							<artifactId>${project.artifactId}</artifactId>
+							<version>${project.version}</version>
+						</annotationProcessorPath>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/TadukooView/.classpath
+++ b/TadukooView/.classpath
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="resource"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
@@ -10,6 +15,11 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path=".apt_generated">
+		<attributes>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/TadukooView/.gitignore
+++ b/TadukooView/.gitignore
@@ -1,1 +1,3 @@
 /target/
+/.apt_generated/
+.factorypath

--- a/TadukooView/pom.xml
+++ b/TadukooView/pom.xml
@@ -8,6 +8,7 @@
 		<version>0.1-Alpha-SNAPSHOT</version>
 	</parent>
 	<artifactId>TadukooView</artifactId>
+	
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -15,6 +16,7 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>

--- a/TadukooView/src/com/gmail/realtadukoo/util/view/Context.java
+++ b/TadukooView/src/com/gmail/realtadukoo/util/view/Context.java
@@ -21,7 +21,7 @@ public abstract class Context{
 	/** The {@link View Views} currently being shown, with the topmost one at the final index */
 	private List<View> currentViewStack;
 	/** The {@link EventHandler EventHandlers} used to handle {@link Event Events} */
-	private Map<Class<? extends EventHandler<?, ?>>, EventHandler<?, ?>> eventHandlers;
+	protected Map<Class<? extends EventHandler<?, ?>>, EventHandler<?, ?>> eventHandlers;
 	
 	/**
 	 * Constructs a new {@link Context}, initializing the various stuff it holds.

--- a/TadukooView/src/com/gmail/realtadukoo/util/view/View.java
+++ b/TadukooView/src/com/gmail/realtadukoo/util/view/View.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.gmail.realtadukoo.util.event.Event;
 import com.gmail.realtadukoo.util.event.EventListener;
 import com.gmail.realtadukoo.util.event.view.ViewChangeEventListener;
 import com.gmail.realtadukoo.util.map.HashMultiMap;

--- a/TadukooView/src/com/gmail/realtadukoo/util/view/draw/Draw.java
+++ b/TadukooView/src/com/gmail/realtadukoo/util/view/draw/Draw.java
@@ -137,9 +137,9 @@ public class Draw{
 		g.drawImage(image, x, y, width, height, null);
 	}
 	
-	public static void drawText(Graphics g, String text, int x, int y, Font font){
+	public static void drawText(Graphics g, String text, int x, int y, Font font, Color color){
 		g.setFont(font);
-		g.setColor(Color.BLACK);
+		g.setColor(color);
 		g.drawString(text, x, y);
 	}
 }

--- a/TadukooView/src/com/gmail/realtadukoo/util/view/draw/Text.java
+++ b/TadukooView/src/com/gmail/realtadukoo/util/view/draw/Text.java
@@ -1,5 +1,6 @@
 package com.gmail.realtadukoo.util.view.draw;
 
+import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Point;
@@ -31,6 +32,7 @@ public class Text extends Drawable{
 	 * <li>fontName - Calibri</li>
 	 * <li>fontStyle - {@link Font#PLAIN}</li>
 	 * <li>fontSize - 25</li>
+	 * <li>color - {@link Color#BLACK}</li>
 	 * <li>Graphics - null - must be set if orienting or fitting to box on 
 	 * initialization</li>
 	 * <li>orient - false - if Graphics is set, can orient on creation, 
@@ -57,6 +59,8 @@ public class Text extends Drawable{
 		private int fontStyle = Font.PLAIN;
 		/** The font size of the Text - default 25 */
 		private int fontSize = 25;
+		/** The Color of the Text - default BLACK */
+		private Color color = Color.BLACK;
 		/** Graphics to use if orienting or fitting the Text object to a box in the build */
 		private Graphics g = null;
 		/** Whether or not to orient the Text object immediately */
@@ -136,6 +140,16 @@ public class Text extends Drawable{
 		 */
 		public TextBuilder fontSize(int fontSize){
 			this.fontSize = fontSize;
+			return this;
+		}
+		
+		/**
+		 * Sets the Color to be used for the Text object
+		 * 
+		 * @param color The Color to be used for the Text object
+		 */
+		public TextBuilder color(Color color){
+			this.color = color;
 			return this;
 		}
 		
@@ -226,7 +240,7 @@ public class Text extends Drawable{
 			}
 			
 			// Created the Text object
-			Text newText = new Text(new Font(fontName, fontStyle, fontSize), text, x, y, orientation);
+			Text newText = new Text(new Font(fontName, fontStyle, fontSize), color, text, x, y, orientation);
 			
 			// Orient the Text if specified
 			if(orient){
@@ -238,6 +252,8 @@ public class Text extends Drawable{
 	
 	/** The {@link Font} to use */
 	private Font font;
+	/** The {@link Color} to use */
+	private Color color;
 	/** The text to draw to the screen */
 	private String text;
 	/** The x coordinate of the text (meaning determined by {@link ORIENTATION}) */
@@ -262,16 +278,18 @@ public class Text extends Drawable{
 	
 	/**
 	 * Create a text object to be drawn to the screen at the given location using 
-	 * the given {@link ORIENTATION} and {@link Font} information.
+	 * the given {@link Color}, {@link ORIENTATION} and {@link Font} information.
 	 * 
-	 * @param Font the {@link Font} to use
+	 * @param font The {@link Font} to use
+	 * @param color The {@link Color} to use
 	 * @param text The text to draw to the screen
 	 * @param x The x coordinate of the text
 	 * @param y The y coordinate of the text
 	 * @param orientation The {@link ORIENTATION} of the text in relation to the given coordinate
 	 */
-	private Text(Font font, String text, int x, int y, ORIENTATION orientation){
+	private Text(Font font, Color color, String text, int x, int y, ORIENTATION orientation){
 		this.font = font;
+		this.color = color;
 		this.text = text;
 		originalX = x;
 		originalY = y;
@@ -306,7 +324,7 @@ public class Text extends Drawable{
 	}
 	
 	/**
-	 * Draws the text to the screen using its coordinates and orientation.
+	 * Draws the text to the screen using its coordinates, orientation, font, and color.
 	 * <br><br>
 	 * Calls {@link Draw#drawText} to actually draw the text.
 	 * 
@@ -315,6 +333,6 @@ public class Text extends Drawable{
 	@Override
 	protected void draw(Graphics g){
 		// Draw the text to the screen
-		Draw.drawText(g, text, x, y, font);
+		Draw.drawText(g, text, x, y, font, color);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gmail.realtadukoo.util</groupId>
 	<artifactId>TadukooUtilParent</artifactId>
@@ -9,7 +11,6 @@
 		<module>TadukooUtil</module>
 		<module>TadukooDatabase</module>
 		<module>TadukooFileFormat</module>
-    <module>TadukooView</module>
-    <module>TadukooEvents</module>
-  </modules>
+		<module>TadukooView</module>
+	</modules>
 </project>


### PR DESCRIPTION
- Can now set Text color in its builder
- TadukooEvents is no longer listed as a module in parent pom (this
caused issues in building)
- Context's eventHandlers map is now protected instead of private so
that subclasses can actually add event handlers to the map
- Documentation fix: View now imports Event as it's used in
documentation
- classpath got updated to say that src folder is pomderived (not sure
why it wasn't before)
- Tadukoo Util now includes itself in annotation processor path in the
pom (unfortunately this is not helpful in Eclipse, but I should be
switching to IntelliJ sometime soon)

Closes #6 